### PR TITLE
Fix `set_{start,end}_time` not to do downcast to OpenTelemtryLayer

### DIFF
--- a/tracing-opentelemetry/src/span_ext.rs
+++ b/tracing-opentelemetry/src/span_ext.rs
@@ -174,7 +174,7 @@ impl OpenTelemetrySpanExt for tracing::Span {
     fn set_start_time(&self, start_time: std::time::SystemTime) {
         self.with_subscriber(|(id, subscriber)| {
             if let Some(get_context) = subscriber.downcast_ref::<WithContext>() {
-                get_context.with_context(subscriber, id, |otel_data, _tracer| {
+                get_context.with_context_minimal(subscriber, id, |otel_data| {
                     otel_data.builder.start_time = Some(start_time);
                 })
             }
@@ -184,7 +184,7 @@ impl OpenTelemetrySpanExt for tracing::Span {
     fn set_end_time(&self, end_time: std::time::SystemTime) {
         self.with_subscriber(|(id, subscriber)| {
             if let Some(get_context) = subscriber.downcast_ref::<WithContext>() {
-                get_context.with_context(subscriber, id, |otel_data, _tracer| {
+                get_context.with_context_minimal(subscriber, id, |otel_data| {
                     otel_data.builder.end_time = Some(end_time);
                 })
             }


### PR DESCRIPTION
## Motivation

`OpenTelemetryLayer::set_{start,end}_time`이 불필요하게 OpenTelemetryLayer로의 downcast를 사용


## Solution

`WithContext`에 OtelData만을 인자로 받는 함수 타입을 추가하여 tracer에 굳이 접근할 필요 없는 경우 사용할 수 있도록 하고, `OpenTelemetryLayer::set_{start,end}_time` 에서 사용

